### PR TITLE
Fix issue with Cyrillic and other scripts

### DIFF
--- a/src/package.json
+++ b/src/package.json
@@ -66,5 +66,8 @@
     "devDependencies": {
         "typescript": "^1.8.5",
         "vscode": "^0.11.0"
+    },
+    "dependencies": {
+        "xregexp": "^3.1.1"
     }
 }

--- a/src/ts/CamelCasing.ts
+++ b/src/ts/CamelCasing.ts
@@ -2,8 +2,11 @@
 // The module 'vscode' contains the VS Code extensibility API
 // Import the module and reference it with the alias vscode in your code below
 import * as vscode from 'vscode';
+const xregexp = require('xregexp');
 
 export class CamelComponent {
+    private static _letterRegexp = new xregexp('\\pL+');
+
     private _text = "";
     public get text(): string {
         return this._text;
@@ -49,8 +52,7 @@ export class CamelComponent {
     }
 
     public static isLetter(char: string) {
-        var retval = /[a-zA-Z\u00C0-\u017F]+/.test(char);        
-        return retval;
+        return CamelComponent._letterRegexp.test(char);
     }
 
     public static isSymbol(char: string) {


### PR DESCRIPTION
I've decided to solve the issue using [xregexp](https://www.npmjs.com/package/xregexp).

So, now we have a runtime dependency on `xregexp`, but Cyrillic finally works okay according to my local tests.

Closes #4.